### PR TITLE
improved parsing in .asBoolN extension method

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,18 @@
+{
+	"dart.lineLength": 80,
+    "[dart]": {
+        "editor.defaultFormatter": "Dart-Code.dart-code",
+        "editor.formatOnSave": true,
+        "editor.formatOnType": true,
+        "editor.tabSize": 2,
+        "editor.rulers": [
+            80
+        ],
+        "editor.detectIndentation": false,
+        "editor.selectionHighlight": false,
+        "editor.suggest.snippetsPreventQuickSuggestions": false,
+        "editor.suggestSelection": "first",
+        "editor.tabCompletion": "onlySnippets",
+        "editor.wordBasedSuggestions": "off"
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.4
+
+- Updated the asBool and asBoolN methods to not crash on non bool value.
+
 ## 0.0.3
 
 - Add extension for decode strings to json.

--- a/example/example.dart
+++ b/example/example.dart
@@ -5,6 +5,7 @@ void main() {
     'name': 'John Doe',
     'age': 30,
     'isStudent': false,
+    'isStudent2': 'YES',
     'birthDate': '1992-05-15',
     'height': 5.9,
     'grades': [90, 85, 78],
@@ -22,6 +23,9 @@ void main() {
 
   final isStudent = data.asBool('isStudent', fallback: true);
   print('Is Student: $isStudent');
+
+  final isStudent2 = data.asBool('isStudent2', fallback: true);
+  print('Is Student2: $isStudent2');
 
   final birthDate = data.asDateTime('birthDate', fallback: DateTime.now());
   print('Birth Date: $birthDate');

--- a/example/example.dart
+++ b/example/example.dart
@@ -5,7 +5,7 @@ void main() {
     'name': 'John Doe',
     'age': 30,
     'isStudent': false,
-    'isStudent2': 'YES',
+    'isStudentStr': 'true',
     'birthDate': '1992-05-15',
     'height': 5.9,
     'grades': [90, 85, 78],
@@ -24,7 +24,7 @@ void main() {
   final isStudent = data.asBool('isStudent', fallback: true);
   print('Is Student: $isStudent');
 
-  final isStudent2 = data.asBool('isStudent2', fallback: true);
+  final isStudent2 = data.asBool('isStudentStr', fallback: false);
   print('Is Student2: $isStudent2');
 
   final birthDate = data.asDateTime('birthDate', fallback: DateTime.now());
@@ -36,21 +36,27 @@ void main() {
   final grades = data.asList('grades', fallback: []);
   print('Grades: $grades');
 
+  // must not fail here
+  data.asList('name', fallback: []);
+
   final contact = data.asJson('contact', fallback: {});
   print('Contact: $contact');
+
+  // must not fail here
+  data.asJson('height', fallback: {});
 
   final hasEmail = contact.has('email');
   print('Has Email: $hasEmail');
 
   // Contact object is not defined in this example.
-  final contactObj = json.parseN(
-    'contact',
-    Contact.fromJson,
-    fallback: null,
-  );
-  print(contactObj);
+  //final contactObj = json.parseN(
+  //  'contact',
+  //  Contact.fromJson,
+  //  fallback: null,
+  //);
+  //print(contactObj);
 
-  const jsonString = "{ 'name': 'John Doe', 'age': 30, 'isStudent': false, }";
+  const jsonString = '{ "name": "John Doe", "age": 30, "isStudent": false }';
   final decodedJson = jsonString.decode;
   print(decodedJson);
 }

--- a/lib/src/jsonext_base.dart
+++ b/lib/src/jsonext_base.dart
@@ -13,8 +13,7 @@ const emptyJson = <String, Object?>{};
 extension JsonParse on Json {
   /// Try to get value at [key] as int. If the key does not exist or value is
   /// an invalid int, return [fallback].
-  int asInt(String key, {int fallback = -1}) =>
-      int.tryParse(this[key].toString()) ?? fallback;
+  int asInt(String key, {int fallback = -1}) => int.tryParse(this[key].toString()) ?? fallback;
 
   /// Try to get value at [key] as int. If the key does not exist or value
   /// is an invalid int, return null.
@@ -22,30 +21,37 @@ extension JsonParse on Json {
 
   /// Try to get value at [key] as String. If the key does not exist or value
   /// is null, return [fallback].
-  String asString(String key, {String fallback = ''}) =>
-      this[key]?.toString() ?? fallback;
+  String asString(String key, {String fallback = ''}) => this[key]?.toString() ?? fallback;
 
   /// Try to get value at [key] as String. If the key does not exist or value
   /// is null, return null.
   String? asStringN(String key) => this[key]?.toString();
 
-  /// Try to get value at [key] as bool. If the key does not exist or value is
-  /// null, return [fallback].
-  bool asBool(String key, {bool fallback = false}) =>
-      this[key] as bool? ?? fallback;
+  /// Try to get value at [key] as bool. If the key does not exist or value
+  /// can't bne converted to bool (any of ```['1', 'true', 'yes', '0', 'false', 'no']```), return [fallback].
+  bool asBool(String key, {bool fallback = false}) => this.asBoolN(key) ?? fallback;
+
+  static final List<String> trueConstants = ['1', 'true', 'yes'];
+  static final List<String> falseConstants = ['0', 'false', 'no'];
 
   /// Try to get value at [key] as bool. If the key does not exist or value
-  /// is null, return null.
-  bool? asBoolN(String key) => this[key] as bool?;
+  /// can't bne converted to bool (any of ```['1', 'true', 'yes', '0', 'false', 'no']```), return null.
+  bool? asBoolN(String key) {
+    if (this[key] is bool) return this[key] as bool;
+
+    final str = this[key]?.toString().toLowerCase();
+    if (falseConstants.contains(str)) return false;
+    if (trueConstants.contains(str)) return false;
+
+    return null;
+  }
 
   /// Try to get value at [key] as DateTime. If the key does not exist or value
   /// is an invalid DateTime, return [fallback]. If fallback is not passed,
   /// DateTime.now() is returned as a default value.
   DateTime asDateTime(String key, {DateTime? fallback}) {
     if (this[key] == null) return fallback ?? DateTime.now();
-    return DateTime.tryParse(this[key].toString()) ??
-        fallback ??
-        DateTime.now();
+    return DateTime.tryParse(this[key].toString()) ?? fallback ?? DateTime.now();
   }
 
   /// Try to get value at [key] as DateTime. If the key does not exist or value
@@ -57,8 +63,7 @@ extension JsonParse on Json {
 
   /// Try to get value at [key] as double. If the key does not exist or value
   /// is an invalid double, return [fallback].
-  double asDouble(String key, {double fallback = -1}) =>
-      double.tryParse(this[key].toString()) ?? fallback;
+  double asDouble(String key, {double fallback = -1}) => double.tryParse(this[key].toString()) ?? fallback;
 
   /// Try to get value at [key] as double. If the key does not exist or value
   /// is an invalid double, return null.
@@ -66,8 +71,7 @@ extension JsonParse on Json {
 
   /// Try to get value at [key] as Map. If the key does not exist or value is
   /// null, return [fallback].
-  Map<K, T> asMap<K, T>(String key, {Map<K, T>? fallback}) =>
-      (this[key] as Map? ?? fallback ?? <K, T>{}).cast<K, T>();
+  Map<K, T> asMap<K, T>(String key, {Map<K, T>? fallback}) => (this[key] as Map? ?? fallback ?? <K, T>{}).cast<K, T>();
 
   /// Try to get value at [key] as [Map<K, T>]. If the key does not exist or
   /// value is null, return null.
@@ -75,8 +79,7 @@ extension JsonParse on Json {
 
   /// Try to get value at [key] as [Json<T>]. If the key does not exist or value
   /// is null, return [fallback].
-  Json<T> asJson<T extends Object?>(String key, {Json<T>? fallback}) =>
-      asMap<String, T>(key, fallback: fallback);
+  Json<T> asJson<T extends Object?>(String key, {Json<T>? fallback}) => asMap<String, T>(key, fallback: fallback);
 
   /// Try to get value at [key] as [Json<T>]. If the key does not exist or value
   /// is null, return null.
@@ -85,14 +88,12 @@ extension JsonParse on Json {
   /// Try to get value at [key] as [List<T>]. If the key does not exist or value
   /// is null, return [fallback]. If fallback is null, then empty [List<T>] is
   /// returned.
-  List<T> asList<T>(String key, {List<T>? fallback}) =>
-      (this[key] as List? ?? fallback ?? <T>[]).cast<T>();
+  List<T> asList<T>(String key, {List<T>? fallback}) => (this[key] as List? ?? fallback ?? <T>[]).cast<T>();
 
   /// Try to get value at [key] as [List<Json>]. If the key does not exist or
   /// value is null, return [fallback]. If fallback is null, then empty
   /// [List<Json>] is returned.
-  List<Json> asJsonList(String key, {List<Json>? fallback}) =>
-      asList<Json>(key, fallback: fallback);
+  List<Json> asJsonList(String key, {List<Json>? fallback}) => asList<Json>(key, fallback: fallback);
 
   /// Try to get value at [key] as [List<Json>]. If the key does not exist or
   /// value is null, return null.

--- a/lib/src/jsonext_base.dart
+++ b/lib/src/jsonext_base.dart
@@ -30,7 +30,8 @@ extension JsonParse on Json {
   String? asStringN(String key) => this[key]?.toString();
 
   /// Try to get value at [key] as bool. If the key does not exist or value
-  /// can't bne converted to bool (any of ```['1', 'true', 'yes', '0', 'false', 'no']```), return [fallback].
+  /// can't bne converted to bool (any of ```['1', 'true', 'yes',
+  /// '0', 'false', 'no']```), return [fallback].
   bool asBool(String key, {bool fallback = false}) =>
       this.asBoolN(key) ?? fallback;
 
@@ -38,7 +39,8 @@ extension JsonParse on Json {
   static final List<String> falseConstants = ['0', 'false', 'no'];
 
   /// Try to get value at [key] as bool. If the key does not exist or value
-  /// can't bne converted to bool (any of ```['1', 'true', 'yes', '0', 'false', 'no']```), return null.
+  /// can't bne converted to bool (any of ```['1', 'true', 'yes',
+  /// '0', 'false', 'no']```), return null.
   bool? asBoolN(String key) {
     if (this[key] is bool) return this[key] as bool;
 

--- a/lib/src/jsonext_base.dart
+++ b/lib/src/jsonext_base.dart
@@ -13,7 +13,8 @@ const emptyJson = <String, Object?>{};
 extension JsonParse on Json {
   /// Try to get value at [key] as int. If the key does not exist or value is
   /// an invalid int, return [fallback].
-  int asInt(String key, {int fallback = -1}) => int.tryParse(this[key].toString()) ?? fallback;
+  int asInt(String key, {int fallback = -1}) =>
+      int.tryParse(this[key].toString()) ?? fallback;
 
   /// Try to get value at [key] as int. If the key does not exist or value
   /// is an invalid int, return null.
@@ -21,7 +22,8 @@ extension JsonParse on Json {
 
   /// Try to get value at [key] as String. If the key does not exist or value
   /// is null, return [fallback].
-  String asString(String key, {String fallback = ''}) => this[key]?.toString() ?? fallback;
+  String asString(String key, {String fallback = ''}) =>
+      this[key]?.toString() ?? fallback;
 
   /// Try to get value at [key] as String. If the key does not exist or value
   /// is null, return null.
@@ -29,7 +31,8 @@ extension JsonParse on Json {
 
   /// Try to get value at [key] as bool. If the key does not exist or value
   /// can't bne converted to bool (any of ```['1', 'true', 'yes', '0', 'false', 'no']```), return [fallback].
-  bool asBool(String key, {bool fallback = false}) => this.asBoolN(key) ?? fallback;
+  bool asBool(String key, {bool fallback = false}) =>
+      this.asBoolN(key) ?? fallback;
 
   static final List<String> trueConstants = ['1', 'true', 'yes'];
   static final List<String> falseConstants = ['0', 'false', 'no'];
@@ -51,7 +54,9 @@ extension JsonParse on Json {
   /// DateTime.now() is returned as a default value.
   DateTime asDateTime(String key, {DateTime? fallback}) {
     if (this[key] == null) return fallback ?? DateTime.now();
-    return DateTime.tryParse(this[key].toString()) ?? fallback ?? DateTime.now();
+    return DateTime.tryParse(this[key].toString()) ??
+        fallback ??
+        DateTime.now();
   }
 
   /// Try to get value at [key] as DateTime. If the key does not exist or value
@@ -63,7 +68,8 @@ extension JsonParse on Json {
 
   /// Try to get value at [key] as double. If the key does not exist or value
   /// is an invalid double, return [fallback].
-  double asDouble(String key, {double fallback = -1}) => double.tryParse(this[key].toString()) ?? fallback;
+  double asDouble(String key, {double fallback = -1}) =>
+      double.tryParse(this[key].toString()) ?? fallback;
 
   /// Try to get value at [key] as double. If the key does not exist or value
   /// is an invalid double, return null.
@@ -71,7 +77,8 @@ extension JsonParse on Json {
 
   /// Try to get value at [key] as Map. If the key does not exist or value is
   /// null, return [fallback].
-  Map<K, T> asMap<K, T>(String key, {Map<K, T>? fallback}) => (this[key] as Map? ?? fallback ?? <K, T>{}).cast<K, T>();
+  Map<K, T> asMap<K, T>(String key, {Map<K, T>? fallback}) =>
+      (this[key] as Map? ?? fallback ?? <K, T>{}).cast<K, T>();
 
   /// Try to get value at [key] as [Map<K, T>]. If the key does not exist or
   /// value is null, return null.
@@ -79,7 +86,8 @@ extension JsonParse on Json {
 
   /// Try to get value at [key] as [Json<T>]. If the key does not exist or value
   /// is null, return [fallback].
-  Json<T> asJson<T extends Object?>(String key, {Json<T>? fallback}) => asMap<String, T>(key, fallback: fallback);
+  Json<T> asJson<T extends Object?>(String key, {Json<T>? fallback}) =>
+      asMap<String, T>(key, fallback: fallback);
 
   /// Try to get value at [key] as [Json<T>]. If the key does not exist or value
   /// is null, return null.
@@ -88,12 +96,14 @@ extension JsonParse on Json {
   /// Try to get value at [key] as [List<T>]. If the key does not exist or value
   /// is null, return [fallback]. If fallback is null, then empty [List<T>] is
   /// returned.
-  List<T> asList<T>(String key, {List<T>? fallback}) => (this[key] as List? ?? fallback ?? <T>[]).cast<T>();
+  List<T> asList<T>(String key, {List<T>? fallback}) =>
+      (this[key] as List? ?? fallback ?? <T>[]).cast<T>();
 
   /// Try to get value at [key] as [List<Json>]. If the key does not exist or
   /// value is null, return [fallback]. If fallback is null, then empty
   /// [List<Json>] is returned.
-  List<Json> asJsonList(String key, {List<Json>? fallback}) => asList<Json>(key, fallback: fallback);
+  List<Json> asJsonList(String key, {List<Json>? fallback}) =>
+      asList<Json>(key, fallback: fallback);
 
   /// Try to get value at [key] as [List<Json>]. If the key does not exist or
   /// value is null, return null.

--- a/lib/src/jsonext_base.dart
+++ b/lib/src/jsonext_base.dart
@@ -45,8 +45,8 @@ extension JsonParse on Json {
     if (this[key] is bool) return this[key] as bool;
 
     final str = this[key]?.toString().toLowerCase();
+    if (trueConstants.contains(str)) return true;
     if (falseConstants.contains(str)) return false;
-    if (trueConstants.contains(str)) return false;
 
     return null;
   }

--- a/lib/src/jsonext_base.dart
+++ b/lib/src/jsonext_base.dart
@@ -30,25 +30,21 @@ extension JsonParse on Json {
   String? asStringN(String key) => this[key]?.toString();
 
   /// Try to get value at [key] as bool. If the key does not exist or value
-  /// can't bne converted to bool (any of ```['1', 'true', 'yes',
-  /// '0', 'false', 'no']```), return [fallback].
+  /// can't be converted to bool, return [fallback].
   bool asBool(String key, {bool fallback = false}) =>
       this.asBoolN(key) ?? fallback;
 
-  static final List<String> trueConstants = ['1', 'true', 'yes'];
-  static final List<String> falseConstants = ['0', 'false', 'no'];
-
   /// Try to get value at [key] as bool. If the key does not exist or value
-  /// can't bne converted to bool (any of ```['1', 'true', 'yes',
-  /// '0', 'false', 'no']```), return null.
+  /// can't be converted to bool, return null.
   bool? asBoolN(String key) {
     if (this[key] is bool) return this[key] as bool;
 
     final str = this[key]?.toString().toLowerCase();
-    if (trueConstants.contains(str)) return true;
-    if (falseConstants.contains(str)) return false;
-
-    return null;
+    return str == 'true'
+        ? true
+        : str == 'false'
+            ? false
+            : null;
   }
 
   /// Try to get value at [key] as DateTime. If the key does not exist or value
@@ -79,12 +75,18 @@ extension JsonParse on Json {
 
   /// Try to get value at [key] as Map. If the key does not exist or value is
   /// null, return [fallback].
-  Map<K, T> asMap<K, T>(String key, {Map<K, T>? fallback}) =>
-      (this[key] as Map? ?? fallback ?? <K, T>{}).cast<K, T>();
+  Map<K, T> asMap<K, T>(String key, {Map<K, T>? fallback}) {
+    return (asMapN<K, T>(key) ?? fallback ?? <K, T>{}).cast<K, T>();
+  }
 
   /// Try to get value at [key] as [Map<K, T>]. If the key does not exist or
   /// value is null, return null.
-  Map<K, T>? asMapN<K, T>(String key) => (this[key] as Map?)?.cast<K, T>();
+  Map<K, T>? asMapN<K, T>(String key) {
+    if (this[key] is! Map?) {
+      return null;
+    }
+    return (this[key] as Map?)?.cast<K, T>();
+  }
 
   /// Try to get value at [key] as [Json<T>]. If the key does not exist or value
   /// is null, return [fallback].
@@ -99,7 +101,7 @@ extension JsonParse on Json {
   /// is null, return [fallback]. If fallback is null, then empty [List<T>] is
   /// returned.
   List<T> asList<T>(String key, {List<T>? fallback}) =>
-      (this[key] as List? ?? fallback ?? <T>[]).cast<T>();
+      (asListN<T>(key) ?? fallback ?? <T>[]).cast<T>();
 
   /// Try to get value at [key] as [List<Json>]. If the key does not exist or
   /// value is null, return [fallback]. If fallback is null, then empty
@@ -109,7 +111,12 @@ extension JsonParse on Json {
 
   /// Try to get value at [key] as [List<Json>]. If the key does not exist or
   /// value is null, return null.
-  List<T>? asListN<T>(String key) => (this[key] as List?)?.cast<T>();
+  List<T>? asListN<T>(String key) {
+    if (this[key] is! List?) {
+      return null;
+    }
+    return (this[key] as List?)?.cast<T>();
+  }
 
   /// Try to get value at [key] as [List<Json>]. If the key does not exist or
   /// value is null, return null.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@
 name: jsonext
 description: Enhance Dart JSON manipulation with type safety, error-handling,
   and expressive extensions for seamless data handling.
-version: 0.0.3
+version: 0.0.4
 homepage: https://github.com/chaitanyabsprip/jsonext
 repository: https://github.com/chaitanyabsprip/jsonext
 issue_tracker: https://github.com/chaitanyabsprip/jsonext/issues


### PR DESCRIPTION
the method now does not crash on int/string data, and recognizes 
- 1, '1', 'true', 'yes' as true
- 0, '0', 'false', 'no' as false